### PR TITLE
Added support for disabling saves.

### DIFF
--- a/src/jumpmod/functions.gsc
+++ b/src/jumpmod/functions.gsc
@@ -432,3 +432,13 @@ numdigits(num)
 {
     return (num + "").size;
 }
+
+is_point_in_AABB(point, box) {
+    return point[0] >= box[0][0] && point[0] <= box[1][0]
+        && point[1] >= box[0][1] && point[1] <= box[1][1]
+        && point[2] >= box[0][2] && point[2] <= box[1][2];
+}
+
+to_string_aabb(box) {
+    return "Box (" + box[0][0] + ", " + box[0][1] + ", " + box[0][2] + "), (" + box[1][0] + ", " + box[1][1] + ", " + box[1][2] + ")";
+}

--- a/src/maps/MP/gametypes/jmp.gsc
+++ b/src/maps/MP/gametypes/jmp.gsc
@@ -396,7 +396,7 @@ jmpSavePosition()
         return;
 
     if(isDefined(self.save_disabled) && self.save_disabled) {
-        self iPrintLn("^1Saving is disabled.  This incident will be reported.");
+        self iPrintLn("^1Saving is disabled."); // This incident will be reported. ;)
         return;
     }
 
@@ -425,43 +425,44 @@ jmpLoadPosition()
     if(self.save_array.size == 0) {
         self iPrintLn("^1You don't have any saved positions.");
         return;
-    } 
+    } else {
+        if(self.load_index == (self.save_array_max_length - 1) || self.load_index >= self.save_array.size) // Make sure the player doesn't try to load a position outside of the save_array size
+            self.load_index = 0;
 
-    if(self.load_index == (self.save_array_max_length - 1) || self.load_index >= self.save_array.size) // Make sure the player doesn't try to load a position outside of the save_array size
-        self.load_index = 0;
-
-    if(!isDefined(self.load_old_pos)) { // Check if load hasn't been used yet
-        self.load_index = 0;
-    } else if(distance(self.load_old_pos, self.origin) > 20) { // If the player has moved more than 20 units, reset the load index back to 0
-        self.load_index = 0;
-    }
-
-    if(positionWouldTelefrag(self.save_array[self.load_index]["origin"])) {
-        if(distance(self.origin, self.save_array[self.load_index]["origin"]) < 33) {
-            // Tillat fordi distansen mellom deg og save-posisjonen er mindre enn 33, og da
-            // betyr dette med all sannsynlighet at det er deg selv som blokkerer posisjonen
-            // Spilleren er 32 units bred, 72 units høy, 33 units passer da bra som distanse
+        if(!isDefined(self.load_old_pos)) { // Check if load hasn't been used yet
+            self.load_index = 0;
         } else {
-            self iPrintLn("^1A player is already on this position.");
-            return;
+            if(distance(self.load_old_pos, self.origin) > 20) // If the player has moved more than 20 units, reset the load index back to 0
+                self.load_index = 0;
         }
-    }
 
-    self setPlayerAngles(self.save_array[self.load_index]["angles"]); // Update the player position
-    self setOrigin(self.save_array[self.load_index]["origin"]);
+        if(positionWouldTelefrag(self.save_array[self.load_index]["origin"])) {
+            if(distance(self.origin, self.save_array[self.load_index]["origin"]) < 33) {
+                // Tillat fordi distansen mellom deg og save-posisjonen er mindre enn 33, og da
+                // betyr dette med all sannsynlighet at det er deg selv som blokkerer posisjonen
+                // Spilleren er 32 units bred, 72 units høy, 33 units passer da bra som distanse
+            } else {
+                self iPrintLn("^1A player is already on this position.");
+                return;
+            }
+        }
 
-    self.load_old_pos = self.origin; // Update the old position
+        self setPlayerAngles(self.save_array[self.load_index]["angles"]); // Update the player position
+        self setOrigin(self.save_array[self.load_index]["origin"]);
 
-    if(self.load_index == 0)
-        self iPrintLn("^1Your saved position is ^2loaded^1.");
-    else
-        self iPrintLn("^1Your backup position #" + self.load_index + " is ^2loaded^1.");
+        self.load_old_pos = self.origin; // Update the old position
 
-    self.load_index++; // Update the load_index
-    
-    if(isDefined(self.save_disabled) && self.save_disabled) {
-        self.save_disabled = false;
-        self iPrintLn("^1Saving ^2enabled!");
+        if(self.load_index == 0)
+            self iPrintLn("^1Your saved position is ^2loaded^1.");
+        else
+            self iPrintLn("^1Your backup position #" + self.load_index + " is ^2loaded^1.");
+
+        self.load_index++; // Update the load_index
+
+        if(isDefined(self.save_disabled) && self.save_disabled) {
+        	self.save_disabled = false;
+        	self iPrintLn("^1Saving ^2enabled!");
+    	}
     }
 }
 


### PR DESCRIPTION
This is only code to support additions in settings.gsc file. The json2gsc submodule is not yet updated and will come in a future PR.
Example settings.gsc:
``` 
case "jm_speed":
            level.maptitle = "jm_speed";
            level.mapauthor = "unknown";
            level.timelimit = 15;
            save_disable_aabb[0][0] = (-166, 400, 70);
            save_disable_aabb[0][1] = (90, 448, 200);
            save_disable_aabb[1][0] = (-324, 1000, 70);
            save_disable_aabb[1][1] = (-244, 1048, 200);
            save_enable_aabb[0][0] = (-166, 326, 70);
            save_enable_aabb[0][1] = (90, 378, 200);
            save_enable_aabb[1][0] = (-324, 1068, 70);
            save_enable_aabb[1][1] = (-244, 1116, 200);
        break;
    
// ...   
 
if(isDefined(save_disable_aabb))
    level.mapsettings["save_disable_aabb"] = save_disable_aabb;
if(isDefined(save_enable_aabb))
    level.mapsettings["save_enable_aabb"] = save_enable_aabb;
        ```